### PR TITLE
modify a few files for easy deploy to pypi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,62 @@
-build/
-*.egg-info/
-dist/
+# Compiled source #
+###################
+*.com
+*.class
+*.dll
+*.exe
+*.o
+*.so
 *.pyc
 
+# OS generated files #
+######################
+.DS_Store
+ehthumbs.db
+Icon
+Thumbs.db
+.tmtags
+.idea
+tags
+vendor.tags
+tmtagsHistory
+*.sublime-project
+*.sublime-workspace
+.bundle
+
+# Distribution / packaging
+##########################
+.Python
+env/
+.env
+venv
+.venv
+ENV/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+.spyderproject
+
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -5,13 +5,23 @@ dcrpm ("detect and correct rpm") is a tool to detect and correct common issues a
 Run `dcrpm` with no option to detect and correct any outstanding issues with RPM on your host. Additional options can be used to customize logging or select specific remediations. dcrpm is meant to be run from cron regularly to keep things happy and healthy.
 
 ## Requirements
-dcrpm requires Python 2.7 and psutil. It should work on any Linux distribution with RPM and on Mac OS X.
+dcrpm requires Python 2.7 and above and the package psutil. It should work on any Linux distribution with RPM and on Mac OS X.
 
 ## Building and installing dcrpm
-The easiest way to install dcrpm is by using pip:
 
-    pip install -r requirements.txt # get psutil
+The easiest way to install dcrpm is get the source and install it using setup.py:
+
     python setup.py install
+
+This will fetch psutils from pypi for you.
+
+
+## Building and installing for develop
+If you want to develop, the easiest way to get dcrpm is by using pip:
+
+    pip install -r requirements.txt # get extra packages
+    python setup.py install
+
 
 ## Contribute
 See the CONTRIBUTING file for how to help out.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[metadata]
+license_file = LICENSE
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,31 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 import os
+import sys
+
 from setuptools import setup
+
 
 __version__ = '0.0.1'
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     long_description = f.read()
+
+
+try:
+    # convert readme to rst so it will be displayed on pypi (not critical so
+    # it's ok to not do it)
+    import pypandoc
+    new_long_description = pypandoc.convert_text(
+        long_description, 'rst', format='md')
+    assert new_long_description
+    long_description = new_long_description
+except Exception:
+    # it's ok if this fails.
+    logging.exception("Could not translate readme into a rst!")
+
 
 setup(
     name='dcrpm',


### PR DESCRIPTION
changes are:

1) set setup.cfg as universal, so we can build 1 wheel for py2 and py3
2) update MANIFEST so we will include LICENSE in sdist and test to make packager life easy.
3)  .gitignore added with common settings, like ignore os specific files and common IDE files
4) update setup.py to generate (if it can) a rst vbersion of the readme... pypi sucks at displaying md, so its better to just upload a rst