### PR TITLE
add basic travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+
+addons:
+  apt:
+    packages:
+      - rpm
+      - yum
+
+script:
+  - python -m unittest discover -v tests

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # dcrpm
+
+[![Build Status](https://travis-ci.org/facebookincubator/dcrpm.svg)](http://travis-ci.org/facebookincubator/dcrpm)
+
 dcrpm ("detect and correct rpm") is a tool to detect and correct common issues around RPM database corruption. It attempts a query against your RPM database and runs db4's `db_recover` if it's hung or otherwise seems broken. It then kills any jobs which had the RPM db open previously since they will be stuck in infinite loops within libdb and can't recover cleanly.
 
 ## Usage


### PR DESCRIPTION
Add a simple config to make sure the tests are passing. This only runs on Linux for now: while Travis has some support for OSX workers, getting Python to run there is really hacky, and it makes the build over 10x slower.

Sample result: https://travis-ci.org/davide125/dcrpm/builds/329992295