### PR TITLE
add __version__ file to dcrpm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include LICENSE
+include LICENSE README.md
 recursive-include tests *.py

--- a/dcrpm/__version__.py
+++ b/dcrpm/__version__.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the GPLv2 license found in the LICENSE
+# file in the root directory of this source tree.
+#
+
+"""
+This is the version file, modify __version__ to update new versions,
+then you can import dcrpm.__version__ to get the current one.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sys
+
+__version__ = '0.0.2'
+
+sys.modules[__name__] = __version__

--- a/dcrpm/main.py
+++ b/dcrpm/main.py
@@ -18,6 +18,7 @@ import logging
 import logging.config
 import sys
 
+from . import __version__
 from .dcrpm import DcRPM
 from .rpmutil import RPMUtil
 
@@ -63,6 +64,10 @@ def parse_args():
     parser = argparse.ArgumentParser(
         prog='dcrpm',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        '--version',
+        action='version', version='%(prog)s ' + __version__
     )
     parser.add_argument(
         '--dry-run',

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,10 @@ from __future__ import unicode_literals
 
 import logging
 import os
-import sys
 
 from setuptools import setup
 
-
-__version__ = '0.0.1'
+import dcrpm.__version__
 
 with open(os.path.join(os.path.dirname(__file__), 'README.md')) as f:
     long_description = f.read()
@@ -40,7 +38,7 @@ except Exception:
 
 setup(
     name='dcrpm',
-    version=__version__,
+    version=dcrpm.__version__,
     packages=['dcrpm'],
     author='Sean Karlage',
     author_email='skarlage@fb.com',


### PR DESCRIPTION
add __version__ file to dcrpm so it will be easy for setup.py and also add --version for `dcrpm --version`

Testing:

python3 setup.py dist -> produce a source dist
python3 setup.py bdist_wheel -> produce a wheel

then i installed the wheel (the thing that probbaly will be installed by most machines) and

```
venv/bin/dcrpm --version
dcrpm 0.0.2
```

also verified that we can install a sdist...