### PR TITLE
Do not fail on yum-complete-transaction timeouts

### DIFF
--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -358,7 +358,12 @@ class RPMUtil:
         """
         cmd = "{} --cleanup".format(self.yum_complete_transaction_path)
         self.status_logger.info(RepairAction.CLEAN_YUM_TRANSACTIONS)
-        run_with_timeout(cmd, YUM_COMPLETE_TIMEOUT_SEC, raise_on_nonzero=False)
+        run_with_timeout(
+            cmd,
+            YUM_COMPLETE_TIMEOUT_SEC,
+            raise_on_nonzero=False,
+            raise_on_timeout=False,
+        )
 
     def kill_spinning_rpm_query_processes(
         self, kill_after_seconds=3600, kill_timeout=5

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -116,6 +116,14 @@ class TestUtil(unittest.TestCase):
         result = run_with_timeout("/bin/true", 5, raise_on_nonzero=False)
         self.assertEqual(result.returncode, 1)
 
+    @patch("subprocess.Popen")
+    def test_run_with_timeout_no_raise_on_timeout(self, mock_popen):
+        mock_popen.return_value = make_mock_popen(returncode=1, communicate_raise=True)
+        result = run_with_timeout("/bin/true", 5, raise_on_timeout=False)
+        self.assertNotEqual(result.returncode, 1)
+        self.assertEqual(result.stdout, None)
+        self.assertEqual(result.stderr, None)
+
     # kindly_end
     def test_kindly_end_terminates(self):
         mock_popen = make_mock_popen()


### PR DESCRIPTION
Akin to
https://github.com/facebookincubator/dcrpm/commit/6d9f42c37dbfd418044c62f38c94334a5c8e56a1
also skip timeout failures so dcrpm can continue fixing stuff