### PR TITLE
Allow overriding checks based on platform

### DIFF
--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -109,6 +109,18 @@ ACTION_NAMES = {
 }
 
 
+def memoize(f):
+    cache = {}
+
+    def wrapper(*args, **kwargs):
+        key = str(args) + str(kwargs)
+        if key not in cache:
+            cache[key] = f(*args, **kwargs)
+        return cache[key]
+
+    return wrapper
+
+
 def alarm_handler(signum, frame):
     # type: (int, Any) -> None
     """

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -22,6 +22,8 @@ class DcrpmIntegrationTest(DcrpmIntegrationTestBase):
     @RPMDB.from_file("rpmdb_fedora26")
     def test_rpmdb_fedora26(self, dbpath):
         self.rpmutil.dbpath = dbpath
+        self.rpmutil.populate_tables()
+        self.rpmutil._read_os_release = lambda: {"ID": "fedora"}
         self.dcrpm.args.dbpath = dbpath
         run_result = self.dcrpm.run()
         self.assertEqual(self.action_trace(), [])
@@ -35,6 +37,8 @@ class DcrpmIntegrationTest(DcrpmIntegrationTestBase):
     # @RPMDB.from_file('rpmdb_centos6')
     # def test_rpmdb_centos6(self, dbpath):
     #     self.rpmutil.dbpath = dbpath
+    #     self.rpmutil.populate_tables()
+    #     self.rpmutil._read_os_release = lambda: {'ID': 'centos'}
     #     self.dcrpm.args.dbpath = dbpath
     #     self.dcrpm.run()
     #     self.assertEqual(
@@ -49,6 +53,8 @@ class DcrpmIntegrationTest(DcrpmIntegrationTestBase):
     @RPMDB.from_file("rpmdb_centos7")
     def test_rpmdb_centos7(self, dbpath):
         self.rpmutil.dbpath = dbpath
+        self.rpmutil.populate_tables()
+        self.rpmutil._read_os_release = lambda: {"ID": "centos"}
         self.dcrpm.args.dbpath = dbpath
         run_result = self.dcrpm.run()
         self.assertEqual(self.action_trace(), [])
@@ -61,6 +67,8 @@ class DcrpmIntegrationTest(DcrpmIntegrationTestBase):
     @RPMDB.from_file("rpmdb_centos7_missing_index")
     def test_rpmdb_centos7_missing_index(self, dbpath):
         self.rpmutil.dbpath = dbpath
+        self.rpmutil.populate_tables()
+        self.rpmutil._read_os_release = lambda: {"ID": "centos"}
         self.dcrpm.args.dbpath = dbpath
         run_result = self.dcrpm.run()
         self.assertEqual(self.action_trace(), [])

--- a/tests/test_pidutil.py
+++ b/tests/test_pidutil.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import signal
+import sys
 import unittest
 from collections import namedtuple
 
@@ -24,12 +25,14 @@ from tests.mock_process import make_mock_process
 
 stat_result = namedtuple("stat_result", ["st_mtime"])
 
-try:
+if sys.version_info[0] == 2:
+    # Python 2
+    builtin_open = "__builtin__.open"
+else:
+    # Python 3
     import builtins
 
     builtin_open = "builtins.open"
-except ImportError:
-    builtin_open = "__builtin__.open"
 
 
 class TestPidutil(unittest.TestCase):


### PR DESCRIPTION
`dcrpm` currently works on CentOS, but the assumptions made don't hold
on a Fedora system. Running `dcrpm` as-is on Fedora:

```
% sudo dcrpm -v
2019-01-08 11:14:49,126 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:14:49,198 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:14:49,199 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:49,215 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:49,231 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:49,231 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:49,232 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is out of whack, deleting it
2019-01-08 11:14:49,249 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:49,249 ERROR [dcrpm.run]: DB needs recovery
2019-01-08 11:14:49,249 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:49,249 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:49,249 INFO [dcrpm.run_recovery]: Attempting to fix RPM DB at /var/lib/rpm
2019-01-08 11:14:49,749 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:49,763 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:49,781 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:49,781 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:49,781 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is missing
2019-01-08 11:14:49,797 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:49,798 ERROR [dcrpm.run]: DB needs rebuild
2019-01-08 11:14:49,798 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:14:49,798 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:14:52,462 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:14:52,531 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:14:52,531 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:52,565 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:52,584 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:52,584 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:52,585 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is out of whack, deleting it
2019-01-08 11:14:52,606 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:52,607 ERROR [dcrpm.run]: DB needs recovery
2019-01-08 11:14:52,607 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:52,607 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:52,607 INFO [dcrpm.run_recovery]: Attempting to fix RPM DB at /var/lib/rpm
2019-01-08 11:14:53,215 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:53,235 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:53,254 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:53,254 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:53,255 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is missing
2019-01-08 11:14:53,273 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:53,273 ERROR [dcrpm.run]: DB needs rebuild
2019-01-08 11:14:53,274 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:14:53,274 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:14:56,252 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:14:56,320 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:14:56,321 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:56,348 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:56,375 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:56,375 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:56,376 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is out of whack, deleting it
2019-01-08 11:14:56,403 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:56,403 ERROR [dcrpm.run]: DB needs recovery
2019-01-08 11:14:56,404 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:56,404 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:14:56,404 INFO [dcrpm.run_recovery]: Attempting to fix RPM DB at /var/lib/rpm
2019-01-08 11:14:57,004 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:14:57,024 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:14:57,050 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:57,050 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:14:57,050 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is missing
2019-01-08 11:14:57,070 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:14:57,071 ERROR [dcrpm.run]: DB needs rebuild
2019-01-08 11:14:57,072 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:14:57,072 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:15:00,787 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:15:00,834 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:15:00,834 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:15:00,857 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:15:00,878 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:00,878 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:00,878 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is out of whack, deleting it
2019-01-08 11:15:00,895 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:15:00,896 ERROR [dcrpm.run]: DB needs recovery
2019-01-08 11:15:00,896 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:15:00,896 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:15:00,896 INFO [dcrpm.run_recovery]: Attempting to fix RPM DB at /var/lib/rpm
2019-01-08 11:15:01,578 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:15:01,594 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:15:01,618 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:01,618 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:01,618 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is missing
2019-01-08 11:15:01,643 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:15:01,644 ERROR [dcrpm.run]: DB needs rebuild
2019-01-08 11:15:01,645 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:15:01,645 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:15:05,401 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:15:05,504 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:15:05,504 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:15:05,536 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:15:05,575 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:05,575 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:05,576 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is out of whack, deleting it
2019-01-08 11:15:05,597 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:15:05,598 ERROR [dcrpm.run]: DB needs recovery
2019-01-08 11:15:05,599 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:15:05,599 INFO [dcrpm.run_recovery]: 1
2019-01-08 11:15:05,600 INFO [dcrpm.run_recovery]: Attempting to fix RPM DB at /var/lib/rpm
2019-01-08 11:15:06,616 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:15:06,651 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:15:06,677 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:06,677 INFO [rpmutil.check_rpmdb_indexes]: 6
2019-01-08 11:15:06,679 INFO [rpmutil.check_rpmdb_indexes]: Obsoletename index is missing
2019-01-08 11:15:06,700 INFO [rpmutil.check_rpmdb_indexes]: Granular index rebuild failed
2019-01-08 11:15:06,701 ERROR [dcrpm.run]: DB needs rebuild
2019-01-08 11:15:06,701 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:15:06,701 INFO [dcrpm.run_rebuild]: 2
2019-01-08 11:15:10,835 ERROR [dcrpm.run]:
2019-01-08 11:15:10,835 ERROR [dcrpm.run]:
2019-01-08 11:15:10,836 ERROR [dcrpm.run]: Unable to repair RPM database
```

With this change, `dcrpm` works on Fedora:

```
% sudo dcrpm -v
2019-01-08 11:07:42,413 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:07:42,464 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:07:42,465 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:07:42,507 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:07:42,528 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Conflictname index
2019-01-08 11:07:42,554 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Providename index
2019-01-08 11:07:42,584 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Basenames index
2019-01-08 11:07:42,635 INFO [dcrpm.run]: Rpmdb indexes OK
2019-01-08 11:07:42,636 INFO [dcrpm.run]: Running black box check (rpm -qa)
2019-01-08 11:07:44,814 INFO [dcrpm.run]: Black box check OK
2019-01-08 11:07:44,814 INFO [dcrpm.run]: Running silent corruption check (rpm -q)
2019-01-08 11:07:44,841 INFO [dcrpm.run]: Silent corruption check OK
2019-01-08 11:07:44,841 INFO [dcrpm.run]: Running table checks (attempting to query each package)
2019-01-08 11:07:46,371 INFO [dcrpm.run]: Table checks OK
2019-01-08 11:07:46,371 INFO [dcrpm.run]: Verifying each table in /var/lib/rpm
2019-01-08 11:07:46,625 WARNING [rpmutil.verify_tables]: Skipping table 'Obsoletename', blacklisted
2019-01-08 11:07:47,466 INFO [dcrpm.call_verify_tables]: Verify tables OK
2019-01-08 11:07:47,467 INFO [dcrpm.run]: Ran a pass without detecting any problems. Exiting.
```

And on CentOS, `dcrpm` still works:

```
% sudo dcrpm -v
2019-01-08 11:09:27,585 INFO [dcrpm.run]: Searching for spinning rpm query processes
2019-01-08 11:09:27,601 INFO [dcrpm.run]: Sanity checking rpmdb indexes
2019-01-08 11:09:27,602 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Requirename index
2019-01-08 11:09:27,617 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Obsoletename index
2019-01-08 11:09:27,628 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Conflictname index
2019-01-08 11:09:27,638 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Providename index
2019-01-08 11:09:27,648 INFO [rpmutil.check_rpmdb_indexes]: Attempting to selectively poke at Basenames index
2019-01-08 11:09:27,666 INFO [dcrpm.run]: Rpmdb indexes OK
2019-01-08 11:09:27,666 INFO [dcrpm.run]: Running black box check (rpm -qa)
2019-01-08 11:09:28,423 INFO [dcrpm.run]: Black box check OK
2019-01-08 11:09:28,423 INFO [dcrpm.run]: Running silent corruption check (rpm -q rpm)
2019-01-08 11:09:28,435 INFO [dcrpm.run]: Silent corruption check OK
2019-01-08 11:09:28,435 INFO [dcrpm.run]: Running table checks (attempting to query each package)
2019-01-08 11:09:29,171 INFO [dcrpm.run]: Table checks OK
2019-01-08 11:09:29,171 INFO [dcrpm.run]: Verifying each table in /var/lib/rpm
2019-01-08 11:09:29,956 WARNING [rpmutil.verify_tables]: Skipping table 'Obsoletename', blacklisted
2019-01-08 11:09:30,030 INFO [dcrpm.call_verify_tables]: Verify tables OK
2019-01-08 11:09:30,030 INFO [dcrpm.run]: Ran a pass without detecting any problems. Exiting.
```

This holds for both Fedora 28 and 29 (the currently-supported Fedora
versions)