### PR TITLE
Fix __db.001 holder detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ dcrpm ("detect and correct rpm") is a tool to detect and correct common issues a
 Run `dcrpm` with no option to detect and correct any outstanding issues with RPM on your host. Additional options can be used to customize logging or select specific remediations. dcrpm is meant to be run from cron regularly to keep things happy and healthy.
 
 ## Requirements
-dcrpm requires Python 2.7 and above and the package psutil. It should work on any Linux distribution with RPM and on Mac OS X.
+dcrpm requires Python 2.7 and above and the package psutil. It also requires `lsof` to be in `$PATH`. It should work on any Linux distribution with RPM and on Mac OS X.
 
 ## Building and installing dcrpm
 The easiest way to install dcrpm is get the source and install it using setup.py:

--- a/dcrpm/dcrpm.py
+++ b/dcrpm/dcrpm.py
@@ -142,9 +142,10 @@ class DcRPM:
         # type: () -> None
         """
         Performs DB recovery by doing the following:
-            * Kills pids holding the .dbenv.lock file
+            * Kills pids holding the .dbenv.lock or .rpm.lock files
             * Hardlinks the __db.001 file (since db_recovery blows it away)
             * Runs db_recovery
+            * Kills pids still holding the __db.001 file
         """
         self.status_logger.info(RepairAction.DB_RECOVERY)
         if self.args.dry_run:
@@ -165,16 +166,22 @@ class DcRPM:
         self.logger.debug("Found %d pids holding lock files", len(lock_procs))
         if lock_procs and pidutil.send_signals(lock_procs, signal.SIGKILL):
             self.logger.debug("Killed pids holding lock files")
-            self.status_logger.warning("killed_lock_users")
+            self.status_logger.info(RepairAction.KILL_LOCK_PIDS)
             return
 
-        # Hardlink to __db.001 and kill holders of that file.
+        # Hardlink to __db.001 so its inode can be found later.
         hardlink = self.hardlink_db001()
-        pidutil.send_signals(pidutil.procs_holding_file(hardlink), signal.SIGKILL)
-        os.unlink(hardlink)
 
         # Run the recovery.
         self.rpmutil.recover_db()
+
+        # Kill any holders of the (now deleted) __db.001.
+        db001_procs = pidutil.procs_holding_file(hardlink)
+        self.logger.debug("Found %d pids holding RPM DB open", len(db001_procs))
+        if db001_procs and pidutil.send_signals(db001_procs, signal.SIGKILL):
+            self.logger.debug("Killed pids holding RPM DB open")
+            self.status_logger.info(RepairAction.KILL_DB001_PIDS)
+        os.unlink(hardlink)
 
     def run_rebuild(self):
         # type: () -> None

--- a/dcrpm/dcrpm.py
+++ b/dcrpm/dcrpm.py
@@ -159,18 +159,18 @@ class DcRPM:
         self.logger.info("Attempting to fix RPM DB at %s", self.args.dbpath)
         dbenv_lockfile = join(self.args.dbpath, ".dbenv.lock")
         rpm_lockfile = join(self.args.dbpath, ".rpm.lock")
-        lock_pids = pidutil.pids_holding_file(dbenv_lockfile)
-        lock_pids |= pidutil.pids_holding_file(rpm_lockfile)
+        lock_procs = pidutil.procs_holding_file(dbenv_lockfile)
+        lock_procs |= pidutil.procs_holding_file(rpm_lockfile)
 
-        self.logger.debug("Found %d pids holding lock files", len(lock_pids))
-        if lock_pids and pidutil.send_signals(lock_pids, signal.SIGKILL):
+        self.logger.debug("Found %d pids holding lock files", len(lock_procs))
+        if lock_procs and pidutil.send_signals(lock_procs, signal.SIGKILL):
             self.logger.debug("Killed pids holding lock files")
             self.status_logger.warning("killed_lock_users")
             return
 
         # Hardlink to __db.001 and kill holders of that file.
         hardlink = self.hardlink_db001()
-        pidutil.send_signals(pidutil.pids_holding_file(hardlink), signal.SIGKILL)
+        pidutil.send_signals(pidutil.procs_holding_file(hardlink), signal.SIGKILL)
         os.unlink(hardlink)
 
         # Run the recovery.

--- a/dcrpm/pidutil.py
+++ b/dcrpm/pidutil.py
@@ -23,7 +23,7 @@ MIN_PID = 2  # Don't kill init/launchd or kernel_task
 logger = logging.getLogger()
 
 
-def pids_holding_file(path):
+def procs_holding_file(path):
     # type: str -> Set[psutil.Process]
     """
     Returns a list of pids holding open file `path`.

--- a/dcrpm/pidutil.py
+++ b/dcrpm/pidutil.py
@@ -14,37 +14,66 @@ import os
 
 import psutil
 
-from dcrpm.util import TimeoutExpired, call_with_timeout
+from dcrpm.util import (
+    DcRPMException,
+    StatusCode,
+    TimeoutExpired,
+    run_with_timeout,
+    which,
+)
 
 
 DEFAULT_TIMEOUT = 5  # seconds
+LSOF_TIMEOUT = 60  # seconds (macOS `lsof` is slow)
 MIN_PID = 2  # Don't kill init/launchd or kernel_task
 
 logger = logging.getLogger()
 
 
+def process(pid):
+    # type: (int) -> Optional[psutil.Process]
+    """
+    Thin wrapper around psutil.Process with exception handling, mainly for
+    encapsulation.
+    """
+    try:
+        return psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        logging.error("Pid %d does not exist or is no longer active", pid)
+        return None
+
+
+def _pids_holding_file(lsof, path):
+    # type: (str, str) -> Set[int]
+    try:
+        cmd = "{} -F p {}".format(lsof, path)
+        proc = run_with_timeout(cmd, LSOF_TIMEOUT, raise_on_nonzero=False)
+    except DcRPMException:
+        logger.warning("lsof timed out")
+        return set()
+
+    if proc.returncode != StatusCode.SUCCESS and proc.stderr:
+        # `lsof` has pretty coarse error reporting. Returning nonzero means either
+        # nothing matched or something went wrong. If nothing matches stderr will
+        # be empty; if it contains output then assume something went wrong (though
+        # "wrong" could be a fairly benign warning, like `path` not existing).
+        logger.warning("lsof returned non-zero: %s", proc.stderr)
+
+    return {int(line[1:]) for line in proc.stdout.splitlines() if line.startswith("p")}
+
+
 def procs_holding_file(path):
     # type: str -> Set[psutil.Process]
     """
-    Returns a list of pids holding open file `path`.
+    Return a set of processes holding `path` open by using `lsof`. `lsof` is slower but
+    will find processes that have other links to the same inode open.
     """
-    procs = set()
-    for proc in psutil.process_iter():
-        try:
-            pinfo = call_with_timeout(
-                proc.as_dict, DEFAULT_TIMEOUT, kwargs={"attrs": ["pid", "open_files"]}
-            )
-        except (psutil.NoSuchProcess, TimeoutExpired):
-            continue
+    lsof = which("lsof")
+    if lsof is None:
+        raise DcRPMException("Couldn't find `lsof` binary")
 
-        # Sometimes open_files can be None.
-        open_files = pinfo.get("open_files", [])
-        if not open_files:
-            continue
-
-        if path in [f.path for f in open_files]:
-            procs.add(proc)
-    return procs
+    procs = [process(pid) for pid in _pids_holding_file(lsof, path)]
+    return set(filter(None, procs))
 
 
 def pidfile_info(pidfile):
@@ -102,16 +131,3 @@ def send_signals(procs, signal, timeout=DEFAULT_TIMEOUT):
     """
     was_killed = [send_signal(p, signal, timeout) for p in procs]
     return any(was_killed)
-
-
-def process(pid):
-    # type: (int) -> Optional[psutil.Process]
-    """
-    Thin wrapper around psutil.Process with exception handling, mainly for
-    encapsulation.
-    """
-    try:
-        return psutil.Process(pid)
-    except psutil.NoSuchProcess:
-        logging.error("Pid %d does not exist or is no longer active", pid)
-        return None

--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -86,6 +86,7 @@ class RepairAction:
     STUCK_YUM = 4
     CLEAN_YUM_TRANSACTIONS = 5
     INDEX_REBUILD = 6
+    KILL_DB001_PIDS = 7
 
 
 class Result:
@@ -102,6 +103,7 @@ ACTION_NAMES = {
     RepairAction.NO_ACTION: "no_action",
     RepairAction.DB_RECOVERY: "db_recovery",
     RepairAction.TABLE_REBUILD: "table_rebuild",
+    RepairAction.KILL_DB001_PIDS: "kill_db001_pids",
     RepairAction.KILL_LOCK_PIDS: "kill_lock_pids",
     RepairAction.STUCK_YUM: "stuck_yum",
     RepairAction.CLEAN_YUM_TRANSACTIONS: "cleanup_yum_transactions",
@@ -223,6 +225,7 @@ def kindly_end(proc, timeout=END_TIMEOUT):
     return rc
 
 
+@memoize
 def which(cmd):
     try:
         from shutil import which

--- a/tests/test_pidutil.py
+++ b/tests/test_pidutil.py
@@ -36,43 +36,43 @@ else:
 
 
 class TestPidutil(unittest.TestCase):
-    # pids_holding_file
-    def test_pids_holding_file_none(self):
+    # procs_holding_file
+    def test_procs_holding_file_none(self):
         procs = [
             make_mock_process(12345, ["/tmp/1", "/tmp/2"]),
             make_mock_process(54321, ["/tmp/1", "/tmp/3"]),
         ]
         with patch("psutil.process_iter", return_value=procs):
-            pids = pidutil.pids_holding_file("/tmp/a")
+            pids = pidutil.procs_holding_file("/tmp/a")
         self.assertEqual(len(pids), 0)
 
-    def test_pids_holding_file_some(self):
+    def test_procs_holding_file_some(self):
         procs = [
             make_mock_process(12345, ["/tmp/a", "/tmp/2"]),
             make_mock_process(54321, ["/tmp/1", "/tmp/3"]),
         ]
         with patch("psutil.process_iter", return_value=procs):
-            procs = pidutil.pids_holding_file("/tmp/a")
+            procs = pidutil.procs_holding_file("/tmp/a")
             self.assertEqual(len(procs), 1)
 
-    def test_pids_holding_file_no_process(self):
+    def test_procs_holding_file_no_process(self):
         procs = [
             # throw only on the one that would match.
             make_mock_process(12345, ["/tmp/a", "/tmp/2"], as_dict_throw=True),
             make_mock_process(54321, ["/tmp/1", "/tmp/3"]),
         ]
         with patch("psutil.process_iter", return_value=procs):
-            procs = pidutil.pids_holding_file("/tmp/a")
+            procs = pidutil.procs_holding_file("/tmp/a")
         self.assertEqual(len(procs), 0)
 
-    def test_pids_holding_file_timeout(self):
+    def test_procs_holding_file_timeout(self):
         procs = [
             make_mock_process(12345, ["/tmp/a", "/tmp/2"]),
             make_mock_process(54321, ["/tmp/1", "/tmp/3"]),
             make_mock_process(12346, ["/tmp/a", "/tmp/3"], timeout=True),
         ]
         with patch("psutil.process_iter", return_value=procs):
-            procs = pidutil.pids_holding_file("/tmp/a")
+            procs = pidutil.procs_holding_file("/tmp/a")
             self.assertEqual(len(procs), 1)
 
     # send_signal


### PR DESCRIPTION
`dcrpm` runs `db_recover` to fix any corruption it finds in the RPM DB. If this happens while other processes have the DB open they may fall into a pathological state (in my observation `yum` and friends can spin in a loop allocating RAM until the host OOMs). `dcrpm` originally fixed this by making a hard link to `__db.001` before recovering the DB (since the recovery unlinks the old DB), then after recovery used `lsof` to find and kill any processes that had the hard link open. This worked because `lsof` will match processes that have a file open by any of the links associated with it.

At some point `lsof` was moved to `psutil` and the ability to find a file by any of its names went away, though the hard linking code remains (and doesn't work at all at the moment). `psutil`'s `open_files` is probably architecture dependent but at least on Linux it basically lists whatever `/proc/pid/fd`'s entries point at. The "second hard link" trick won't find processes that opened the DB under a different name.

This PR reinstates using `lsof` for this purpose. It's not ideal to have an additional `procs_holding_file` function (or to rely on calling out) but it's the simplest way to make this work on Linux and OS X.

An alternative to this is to preserve the current order of operation (try to find DB holders before recovering the DB) and just look for processes holding `__db.001` directly. This would certainly be simpler but it's racy — another program could open the DB just before recovering the DB. This is probably a pretty small window of opportunity (`psutil` seems fast) but if a race is possible one day we'll probably hit it.

I tested this on both Linux and OS X by making a small patch that forces `run_recovery` to run. I then opened the DB in a Python terminal and ran `dcrpm`. In both cases my Python shell was `SIGKILL`ed.