### PR TITLE
Don't execute commands via a shell

### DIFF
--- a/dcrpm/pidutil.py
+++ b/dcrpm/pidutil.py
@@ -46,7 +46,7 @@ def process(pid):
 def _pids_holding_file(lsof, path):
     # type: (str, str) -> Set[int]
     try:
-        cmd = "{} -F p {}".format(lsof, path)
+        cmd = [lsof, "-F", "-p", path]
         proc = run_with_timeout(cmd, LSOF_TIMEOUT, raise_on_nonzero=False)
     except DcRPMException:
         logger.warning("lsof timed out")

--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -165,20 +165,16 @@ def call_with_timeout(func, timeout, raise_=True, args=None, kwargs=None):
 
 
 def run_with_timeout(cmd, timeout, raise_on_nonzero=True, raise_on_timeout=True):
-    # type: (str, int, bool) -> CompletedProcess
+    # type: (List[str], int, bool) -> CompletedProcess
     """
     Runs command `cmd` with timeout `timeout`. If `raise_on_nonzero` is True,
     raises a DcRPMException if `cmd` exits with a nonzero status. If
     `raise_on_timeout` is true, raises a DcRPMException if `cmd` times out.
     """
     _logger.debug("Running %s", cmd)
-    cmdname = cmd.split()[0]
+    cmdname = cmd[0]
     proc = subprocess.Popen(
-        cmd,
-        shell=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True
     )
     try:
         stdout, stderr = call_with_timeout(proc.communicate, timeout)

--- a/dcrpm/yum.py
+++ b/dcrpm/yum.py
@@ -86,7 +86,7 @@ class Yum:
         were busted
         """
         try:
-            cmd = "{} clean expire-cache".format(YUM_CMD_NAME)
+            cmd = [YUM_CMD_NAME, "clean", "expire-cache"]
             run_with_timeout(cmd, YUM_TIMEOUT_SEC)
         except DcRPMException:
             raise DBNeedsRebuild
@@ -97,7 +97,7 @@ class Yum:
         Run yum check - which "Checks for problems in the rpmdb"
         """
         try:
-            cmd = "{} check".format(YUM_CMD_NAME)
+            cmd = [YUM_CMD_NAME, "check"]
             run_with_timeout(cmd, YUM_TIMEOUT_SEC)
         except DcRPMException:
             raise DBNeedsRebuild

--- a/tests/test_dcrpm.py
+++ b/tests/test_dcrpm.py
@@ -21,8 +21,7 @@ except ImportError:
 
 from dcrpm.dcrpm import DcRPM
 from dcrpm.rpmutil import RPMUtil
-from dcrpm.util import DcRPMException
-
+from dcrpm.util import DcRPMException, run_with_timeout, which
 
 MockPopenFile = namedtuple("MockPopenFile", ["path"])
 statvfs_result = namedtuple("statvfs_result", ["f_bsize", "f_bfree"])
@@ -30,12 +29,14 @@ statvfs_result = namedtuple("statvfs_result", ["f_bsize", "f_bfree"])
 
 class TestDcRPM(unittest.TestCase):
     def setUp(self):
-        self.rpm_path = "/usr/bin/rpm"
-        self.dbpath = "/var/lib/rpm"
-        self.recover_path = "/usr/bin/db_recover"
-        self.verify_path = "/usr/bin/db_verify"
-        self.stat_path = "/usr/bin/db_stat"
-        self.yum_complete_transaction_path = "/usr/bin/yum-complete-transaction"
+        self.rpm_path = which("rpm")
+        self.dbpath = run_with_timeout(
+            [self.rpm_path, "--eval", "%{_dbpath}"], 5
+        ).stdout.strip()
+        self.recover_path = which("db_recover")
+        self.verify_path = which("db_verify")
+        self.stat_path = which("db_stat")
+        self.yum_complete_transaction_path = which("yum-complete-transaction")
         self.blacklist = ["table1", "table2"]
         self.rpmutil = RPMUtil(
             dbpath=self.dbpath,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -71,11 +71,10 @@ class TestUtil(unittest.TestCase):
     # run_with_timeout
     @patch("subprocess.Popen", return_value=make_mock_popen())
     def test_run_with_timeout_success(self, mock_popen):
-        result = run_with_timeout("/bin/true", 5)
+        result = run_with_timeout(["/bin/true", "noop"], 5)
         self.assertEqual(result.returncode, 0)
         mock_popen.assert_called_once_with(
-            "/bin/true",
-            shell=True,
+            ["/bin/true", "noop"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             universal_newlines=True,


### PR DESCRIPTION
Although dcrpm doesn't typically run suid or anything similarly scary
it's good practice to `exec` without an intermediate shell. This PR
changes `run_with_timeout` to split commands into tokens that can be
passed to `subprocess.Popen` as an array, thus ensuring shell trickery
can't make dcrpm run something it shouldn't. Another option would be to
change all callsites to pass an array directly but I don't we'd get much
more from the inconvenience.

As part of this work I refactored `check_tables` to replace the previous
shell pipeline with two `rpm` invocations.