### PR TITLE
Only perform package count check on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
       script: black --check .
     - name: "Pyre typechecking"
       python: 3.6
-      install: pip install -r requirements.txt pyre-check
+      install: pip install -r requirements.txt pyre-check==0.0.20
       script: scripts/run_pyre_venv.sh
 
 before_install: |

--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -122,6 +122,7 @@ class RPMUtil:
         Call platform.system() and caches the value
         """
         import platform
+
         return platform.system()
 
     @memoize

--- a/tests/test_rpmutil.py
+++ b/tests/test_rpmutil.py
@@ -10,6 +10,7 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import platform
 import time
 import typing as t  # noqa
 
@@ -123,7 +124,7 @@ class TestRPMUtil(testslide.TestCase):
         ).and_assert_called_once()
         self.rpmutil.check_rpm_qa()
 
-    def test_check_rpm_qa_not_enough_packages(self):
+    def test_check_rpm_qa_not_enough_packages_linux(self):
         # type: () -> None
         (
             self.mock_callable(rpmutil, "run_with_timeout")
@@ -132,8 +133,33 @@ class TestRPMUtil(testslide.TestCase):
             )
             .and_assert_called_once()
         )
+        (
+            self.mock_callable(platform, "system")
+            .to_return_value("Linux")
+            .and_assert_called_once()
+        )
         with self.assertRaises(DBNeedsRecovery):
             self.rpmutil.check_rpm_qa()
+
+    def test_check_rpm_qa_not_enough_packages_darwin(self):
+        # type: () -> None
+        (
+            self.mock_callable(rpmutil, "run_with_timeout")
+            .to_return_value(
+                CompletedProcess(stdout="\n".join(["rpm%s" % i for i in range(5)]))
+            )
+            .and_assert_called_once()
+        )
+        (
+            self.mock_callable(platform, "system")
+            .to_return_value("Darwin")
+            .and_assert_called_once()
+        )
+        try:
+            self.rpmutil.check_rpm_qa()
+        except DBNeedsRecovery:
+            self.fail("Package count check should be bypassed on macOS")
+
 
     def test_check_rpm_qa_raise_on_nonzero_rc(self):
         # type: () -> None

--- a/tests/test_rpmutil.py
+++ b/tests/test_rpmutil.py
@@ -160,7 +160,6 @@ class TestRPMUtil(testslide.TestCase):
         except DBNeedsRecovery:
             self.fail("Package count check should be bypassed on macOS")
 
-
     def test_check_rpm_qa_raise_on_nonzero_rc(self):
         # type: () -> None
         (

--- a/tests/test_rpmutil.py
+++ b/tests/test_rpmutil.py
@@ -16,7 +16,7 @@ import typing as t  # noqa
 
 import psutil
 import testslide
-from dcrpm import rpmutil
+from dcrpm import rpmutil, util
 from dcrpm.util import CompletedProcess, DBNeedsRebuild, DBNeedsRecovery, DcRPMException
 from tests.mock_process import make_mock_process
 
@@ -164,7 +164,7 @@ class TestRPMUtil(testslide.TestCase):
         # type: () -> None
         (
             self.mock_callable(rpmutil, "run_with_timeout")
-            .to_return_value(CompletedProcess(returncode=1))
+            .to_raise(DcRPMException)
             .and_assert_called_once()
         )
         with self.assertRaises(DBNeedsRecovery):


### PR DESCRIPTION
`dcrpm` considers the RPM database broken if the number of installed packages is below the threshold (currently 50).

This makes sense on Linux distributions that natively use RPM for package management (CentOS, Fedora) but not on
other platforms, for example macOS, where the total package count might legitimately be below this threshold.

Bypass the package count check if `dcrpm` is not running on Linux.