### PR TITLE
Pin TestSlide to 1.4.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock; python_version < '3.6'
 psutil
 typing; python_version < '3.6'
-TestSlide
+TestSlide==1.4.10

--- a/tests/test_dcrpm.py
+++ b/tests/test_dcrpm.py
@@ -80,27 +80,15 @@ class TestDcRPM(testslide.TestCase):
     # run_recovery
     def test_run_recovery_dry_run(self):
         # type: () -> None
-        (
-            self.mock_callable(pidutil, "send_signals")
-            .to_return_value(None)
-            .and_assert_not_called()
-        )
-        (
-            self.mock_callable(self.rpmutil, "recover_db")
-            .to_return_value(None)
-            .and_assert_not_called()
-        )
+        self.mock_callable(pidutil, "send_signals").and_assert_not_called()
+        self.mock_callable(self.rpmutil, "recover_db").and_assert_not_called()
         self.args.dry_run = True
         self.dcrpm.run_recovery()
 
     # db_stat
     def test_db_stat_forensic(self):
         # type: () -> None
-        (
-            self.mock_callable(pidutil, "send_signals")
-            .to_return_value(None)
-            .and_assert_not_called()
-        )
+        self.mock_callable(pidutil, "send_signals").and_assert_not_called()
         (
             self.mock_callable(self.rpmutil, "db_stat")
             .to_return_value(None)
@@ -113,11 +101,7 @@ class TestDcRPM(testslide.TestCase):
     # run_rebuild
     def test_run_rebuild_dry_run(self):
         # type: () -> None
-        (
-            self.mock_callable(self.rpmutil, "rebuild_db")
-            .to_return_value(None)
-            .and_assert_not_called()
-        )
+        self.mock_callable(self.rpmutil, "rebuild_db").and_assert_not_called()
         self.args.dry_run = True
         self.dcrpm.run_rebuild()
 

--- a/tests/test_pidutil.py
+++ b/tests/test_pidutil.py
@@ -172,12 +172,7 @@ class TestPidfileInfo(testslide.TestCase):
             .with_implementation(mock_open(read_data="-1"))
             .and_assert_called_once()
         )
-        (
-            self.mock_callable(os, "stat")
-            .for_call("/something")
-            .to_return_value(stat_result(12345678))
-            .and_assert_not_called()
-        )
+        self.mock_callable(os, "stat").and_assert_not_called()
         with self.assertRaises(ValueError):
             pid, _ = pidutil.pidfile_info("/something")
 
@@ -189,11 +184,6 @@ class TestPidfileInfo(testslide.TestCase):
             .with_implementation(mock_open(read_data="ooglybogly"))
             .and_assert_called_once()
         )
-        (
-            self.mock_callable(os, "stat")
-            .for_call("/something")
-            .to_return_value(stat_result(12345678))
-            .and_assert_not_called()
-        )
+        self.mock_callable(os, "stat").and_assert_not_called()
         with self.assertRaises(ValueError):
             pid, _ = pidutil.pidfile_info("/something")

--- a/tests/test_rpmutil.py
+++ b/tests/test_rpmutil.py
@@ -228,11 +228,7 @@ class TestRPMUtil(testslide.TestCase):
 
     def test_verify_tables_all_blacklisted(self):
         # type: () -> None
-        (
-            self.mock_callable(rpmutil, "run_with_timeout")
-            .to_return_value(None)
-            .and_assert_not_called()
-        )
+        self.mock_callable(rpmutil, "run_with_timeout").and_assert_not_called()
         self.rpmutil.tables = self.rpmutil.tables[1:3]
         self.rpmutil.verify_tables()
 


### PR DESCRIPTION
TestSlide is deprecating support for python 3.4, but dcrpm must maintain
compatibility with this version because versions of cent7 ship with
python modules that are only distributed with this version.