### PR TITLE
Change run_with_timeout to argv instead of str

### DIFF
--- a/dcrpm/pidutil.py
+++ b/dcrpm/pidutil.py
@@ -48,8 +48,9 @@ def process(pid):
 def _pids_holding_file(lsof, path):
     # type: (str, str) -> t.Set[int]
     try:
-        cmd = "{} -F p {}".format(lsof, path)
-        proc = run_with_timeout(cmd, LSOF_TIMEOUT, raise_on_nonzero=False)
+        proc = run_with_timeout(
+            [lsof, "-F", "p", path], LSOF_TIMEOUT, raise_on_nonzero=False
+        )
     except DcRPMException:
         logger.warning("lsof timed out")
         return set()

--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -109,7 +109,7 @@ class RPMUtil:
             self.logger.error("db_stat -CA failed")
 
     def _poke_index(self, cmd, checks):
-        # type: (str, t.Iterable[Check]) -> None
+        # type: (t.Sequence[str], t.Iterable[Check]) -> None
         """
         Run cmd, and ensure all checks are True. Raise DBIndexNeedsRebuild otherwise
         """
@@ -170,7 +170,7 @@ class RPMUtil:
                 ],
             },
             "Conflictname": {
-                "comd": [
+                "cmd": [
                     self.rpm_path,
                     "-q",
                     "--conflics",
@@ -282,7 +282,7 @@ class RPMUtil:
                         lambda proc: len(proc.stdout.splitlines()) >= 1,
                     ],
                 },
-            }  # type: t.Dict[str, t.Dict[str, t.Union[str, t.Iterable[Check]]]]
+            }  # type: t.Dict[str, t.Dict[str, t.Union[t.Iterable[str], t.Iterable[Check]]]]
             rpmdb_indexes.update(d)
 
         # Checks for Packages db corruption

--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -240,7 +240,7 @@ class RPMUtil:
             "Supplementname": None,  # rarely used
             "Transfiletriggername": None,  # rarely used
             "Triggername": None,  # rarely used
-        }  # type: t.Dict[str, t.Optional[t.Dict[str, t.Union[str, t.Iterable[Check]]]]]
+        }  # type: t.Dict[str, t.Optional[t.Dict[str, t.Union[t.Sequence[str], t.Sequence[Check]]]]]
 
         # For some platforms, the command and/or checks need to be tweaked
         os_release_data = self._read_os_release()
@@ -282,7 +282,7 @@ class RPMUtil:
                         lambda proc: len(proc.stdout.splitlines()) >= 1,
                     ],
                 },
-            }  # type: t.Dict[str, t.Dict[str, t.Union[t.Iterable[str], t.Iterable[Check]]]]
+            }  # type: t.Dict[str, t.Dict[str, t.Union[t.Sequence[str], t.Sequence[Check]]]]
             rpmdb_indexes.update(d)
 
         # Checks for Packages db corruption
@@ -308,7 +308,10 @@ class RPMUtil:
                     continue
 
                 self.logger.info("Attempting to selectively poke at %s index", index)
-                self._poke_index(config["cmd"], t.cast(t.List[Check], config["checks"]))
+                self._poke_index(
+                    t.cast(t.List[str], config["cmd"]),
+                    t.cast(t.List[Check], config["checks"]),
+                )
 
             except DBIndexNeedsRebuild:
                 self.status_logger.info(RepairAction.INDEX_REBUILD)
@@ -321,7 +324,9 @@ class RPMUtil:
 
                 # Run the same command again, which should trigger a rebuild
                 proc = run_with_timeout(
-                    config["cmd"], RPM_CHECK_TIMEOUT_SEC, raise_on_nonzero=False
+                    t.cast(t.List[str], config["cmd"]),
+                    RPM_CHECK_TIMEOUT_SEC,
+                    raise_on_nonzero=False,
                 )
 
                 # Sometimes single index rebuilds don't work, as rpm fails to

--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -93,8 +93,11 @@ class RPMUtil:
         environment.
         """
         try:
-            cmd = "{} -CA -h {}".format(self.stat_path, self.dbpath)
-            ds = run_with_timeout(cmd, RPM_CHECK_TIMEOUT_SEC, raise_on_nonzero=False)
+            ds = run_with_timeout(
+                [self.stat_path, "-CA", "-h", self.dbpath],
+                RPM_CHECK_TIMEOUT_SEC,
+                raise_on_nonzero=False,
+            )
             if ds.returncode > 0:
                 # Sometimes db_stat can fail, let's try to preserve that
                 debug = ds.stderr
@@ -159,9 +162,7 @@ class RPMUtil:
 
         rpmdb_indexes = {
             "Basenames": {
-                "cmd": "{} -qf {} --dbpath {}".format(
-                    self.rpm_path, self.rpm_path, self.dbpath
-                ),
+                "cmd": [self.rpm_path, "-qf", self.rpm_path, "--dbpath", self.dbpath],
                 "checks": [
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) == 1,
@@ -169,27 +170,42 @@ class RPMUtil:
                 ],
             },
             "Conflictname": {
-                "cmd": "{} -q --conflicts initscripts --dbpath {}".format(
-                    self.rpm_path, self.dbpath
-                ),
+                "comd": [
+                    self.rpm_path,
+                    "-q",
+                    "--conflics",
+                    "initscripts",
+                    "--dbpath",
+                    self.dbpath,
+                ],
                 "checks": [
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) > 3,
                 ],
             },
             "Obsoletename": {
-                "cmd": "{} -q --obsoletes coreutils --dbpath {}".format(
-                    self.rpm_path, self.dbpath
-                ),
+                "cmd": [
+                    self.rpm_path,
+                    "-q",
+                    "--obsoletes",
+                    "coreutils",
+                    "--dbpath",
+                    self.dbpath,
+                ],
                 "checks": [
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) > 2,
                 ],
             },
             "Providename": {
-                "cmd": "{} -q --whatprovides rpm --dbpath {}".format(
-                    self.rpm_path, self.dbpath
-                ),
+                "cmd": [
+                    self.rpm_path,
+                    "-q",
+                    "--whatprovides",
+                    "rpm",
+                    "--dbpath",
+                    self.dbpath,
+                ],
                 "checks": [
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) == 1,
@@ -197,9 +213,14 @@ class RPMUtil:
                 ],
             },
             "Requirename": {
-                "cmd": "{} -q --whatrequires rpm --dbpath {}".format(
-                    self.rpm_path, self.dbpath
-                ),
+                "cmd": [
+                    self.rpm_path,
+                    "-q",
+                    "--whatrequires",
+                    "rpm",
+                    "--dbpath",
+                    self.dbpath,
+                ],
                 "checks": [
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) >= 1,
@@ -234,18 +255,28 @@ class RPMUtil:
             #   itself.
             d = {
                 "Conflictname": {
-                    "cmd": "{} -q --conflicts systemd --dbpath {}".format(
-                        self.rpm_path, self.dbpath
-                    ),
+                    "cmd": [
+                        self.rpm_path,
+                        "-q",
+                        "--conflicts",
+                        "systemd",
+                        "--dbpath",
+                        self.dbpath,
+                    ],
                     "checks": [
                         lambda proc: proc.returncode != StatusCode.SEGFAULT,
                         lambda proc: len(proc.stdout.splitlines()) >= 2,
                     ],
                 },
                 "Obsoletename": {
-                    "cmd": "{} -q --obsoletes coreutils --dbpath {}".format(
-                        self.rpm_path, self.dbpath
-                    ),
+                    "cmd": [
+                        self.rpm_path,
+                        "-q",
+                        "--obsoletes",
+                        "coreutils",
+                        "--dbpath",
+                        self.dbpath,
+                    ],
                     "checks": [
                         lambda proc: proc.returncode != StatusCode.SEGFAULT,
                         lambda proc: len(proc.stdout.splitlines()) >= 1,
@@ -277,9 +308,7 @@ class RPMUtil:
                     continue
 
                 self.logger.info("Attempting to selectively poke at %s index", index)
-                self._poke_index(
-                    str(config["cmd"]), t.cast(t.List[Check], config["checks"])
-                )
+                self._poke_index(config["cmd"], t.cast(t.List[Check], config["checks"]))
 
             except DBIndexNeedsRebuild:
                 self.status_logger.info(RepairAction.INDEX_REBUILD)
@@ -292,7 +321,7 @@ class RPMUtil:
 
                 # Run the same command again, which should trigger a rebuild
                 proc = run_with_timeout(
-                    str(config["cmd"]), RPM_CHECK_TIMEOUT_SEC, raise_on_nonzero=False
+                    config["cmd"], RPM_CHECK_TIMEOUT_SEC, raise_on_nonzero=False
                 )
 
                 # Sometimes single index rebuilds don't work, as rpm fails to
@@ -312,8 +341,9 @@ class RPMUtil:
         Runs `rpm -qa` which serves as a good proxy check for whether bdb needs recovery
         """
         try:
-            cmd = "{} --dbpath {} -qa".format(self.rpm_path, self.dbpath)
-            result = run_with_timeout(cmd, RPM_CHECK_TIMEOUT_SEC)
+            result = run_with_timeout(
+                [self.rpm_path, "--dbpath", self.dbpath, "-qa"], RPM_CHECK_TIMEOUT_SEC
+            )
         except DcRPMException:
             self.logger.error("rpm -qa failed")
             self.status_logger.warning("initial_db_check_fail")
@@ -341,8 +371,10 @@ class RPMUtil:
         results (like 'perl' >.>)
         """
         try:
-            cmd = "{} --dbpath {} -q {}".format(self.rpm_path, self.dbpath, rpm_name)
-            result = run_with_timeout(cmd, RPM_CHECK_TIMEOUT_SEC)
+            result = run_with_timeout(
+                [self.rpm_path, "--dbpath", self.dbpath, "-q", rpm_name],
+                RPM_CHECK_TIMEOUT_SEC,
+            )
             stdout = result.stdout.strip().split()
             if not len(stdout) == 1 or not stdout[0].startswith("{}-".format(rpm_name)):
                 raise DBNeedsRebuild()
@@ -357,9 +389,11 @@ class RPMUtil:
         """
         Runs `db_recover`.
         """
-        cmd = "{} -h {}".format(self.recover_path, self.dbpath)
-
-        proc = run_with_timeout(cmd, RECOVER_TIMEOUT_SEC, raise_on_nonzero=False)
+        proc = run_with_timeout(
+            [self.recover_path, "-h", self.dbpath],
+            RECOVER_TIMEOUT_SEC,
+            raise_on_nonzero=False,
+        )
         # We've seen an unrecoverable failure mode where
         # db_recover segfaults, remediable only by a rebuild
         if proc.returncode != StatusCode.SUCCESS:
@@ -380,9 +414,11 @@ class RPMUtil:
         """
         Runs `rpm --rebuilddb`.
         """
-        cmd = "{} --dbpath {} --rebuilddb".format(self.rpm_path, self.dbpath)
         try:
-            run_with_timeout(cmd, REBUILD_TIMEOUT_SEC)
+            run_with_timeout(
+                [self.rpm_path, "--dbpath", self.dbpath, "--rebuilddb"],
+                REBUILD_TIMEOUT_SEC,
+            )
         except DcRPMException:
             self.status_logger.warning("rebuild_tables_failed")
             raise
@@ -390,28 +426,36 @@ class RPMUtil:
     def check_tables(self):
         # type: () -> None
         """
-        Runs the following:
+        Runs the equivalent of:
 
           `rpm -qa --qf | sort | uniq | xargs rpm -q | grep 'is not installed$'`
 
         which checks each rpm in the DB to see if there are inconsistencies between what
         rpm thinks is installed and what is in the DB.
         """
-        cmd = (
-            "{rpm} --dbpath {db} -qa --qf '%{NAME}\\n' | sort | uniq | "
-            "xargs {rpm} --dbpath {db} -q | grep 'is not installed$'"
-        ).format(rpm=self.rpm_path, db=self.dbpath, NAME="NAME")
-
         try:
             result = run_with_timeout(
-                cmd, timeout=RPM_CHECK_TIMEOUT_SEC, raise_on_nonzero=False
+                [self.rpm_path, "--dbpath", self.dbpath, "-qa", "--qf", "%{NAME}\\n"],
+                timeout=RPM_CHECK_TIMEOUT_SEC,
+                exception_to_raise=DBNeedsRebuild,
             )
-        except DcRPMException:
+
+            # Assume healthy if no RPMs listed.
+            rpms = sorted(set(result.stdout.splitlines()))
+            if not rpms:
+                return
+            result = run_with_timeout(
+                [self.rpm_path, "--dbpath", self.dbpath, "-q"] + rpms,
+                timeout=RPM_CHECK_TIMEOUT_SEC,
+                exception_to_raise=DBNeedsRebuild,
+            )
+
+        except DcRPMException as e:
             self.status_logger.warning("initial_table_check_fail")
             raise
 
-        # Grep exit code 1 indicates it didn't find bad condition.
-        if result.returncode == 0:
+        lines = result.stdout.splitlines()
+        if any([line.endswith("is not installed") for line in lines]):
             raise DBNeedsRebuild()
 
     def verify_tables(self):
@@ -424,10 +468,11 @@ class RPMUtil:
                 self.logger.warning("Skipping table '%s', blacklisted", table)
                 continue
 
-            cmd = "{} {}".format(self.verify_path, os.path.join(self.dbpath, table))
             try:
                 result = run_with_timeout(
-                    cmd, VERIFY_TIMEOUT_SEC, raise_on_nonzero=False
+                    [self.verify_path, os.path.join(self.dbpath, table)],
+                    VERIFY_TIMEOUT_SEC,
+                    raise_on_nonzero=False,
                 )
             except DcRPMException:
                 self.status_logger.warning("initial_table_verify_fail")
@@ -444,10 +489,9 @@ class RPMUtil:
         """
         Runs yum-complete-transaction.
         """
-        cmd = "{} --cleanup".format(self.yum_complete_transaction_path)
         self.status_logger.info(RepairAction.CLEAN_YUM_TRANSACTIONS)
         run_with_timeout(
-            cmd,
+            [self.yum_complete_transaction_path, "--cleanup"],
             YUM_COMPLETE_TIMEOUT_SEC,
             raise_on_nonzero=False,
             raise_on_timeout=False,

--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -173,7 +173,7 @@ class RPMUtil:
                 "cmd": [
                     self.rpm_path,
                     "-q",
-                    "--conflics",
+                    "--conflicts",
                     "initscripts",
                     "--dbpath",
                     self.dbpath,

--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -183,7 +183,7 @@ def run_with_timeout(
     timeout,  # type: int
     raise_on_nonzero=True,  # type: bool
     raise_on_timeout=True,  # type: bool
-    exception_to_raise=DcRPMException,  # type: Exception
+    exception_to_raise=DcRPMException,  # type: t.Type[Exception]
 ):
     # type: (...) -> CompletedProcess
     """

--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -179,7 +179,7 @@ def call_with_timeout(
 
 
 def run_with_timeout(
-    cmd,  # type: t.List[str]
+    cmd,  # type: t.Sequence[str]
     timeout,  # type: int
     raise_on_nonzero=True,  # type: bool
     raise_on_timeout=True,  # type: bool

--- a/dcrpm/yum.py
+++ b/dcrpm/yum.py
@@ -88,8 +88,7 @@ class Yum:
         were busted
         """
         try:
-            cmd = "{} clean expire-cache".format(YUM_CMD_NAME)
-            run_with_timeout(cmd, YUM_TIMEOUT_SEC)
+            run_with_timeout([YUM_CMD_NAME, "clean", "expire-cache"], YUM_TIMEOUT_SEC)
         except DcRPMException:
             raise DBNeedsRebuild
 
@@ -99,7 +98,6 @@ class Yum:
         Run yum check - which "Checks for problems in the rpmdb"
         """
         try:
-            cmd = "{} check".format(YUM_CMD_NAME)
-            run_with_timeout(cmd, YUM_TIMEOUT_SEC)
+            run_with_timeout([YUM_CMD_NAME, "check"], YUM_TIMEOUT_SEC)
         except DcRPMException:
             raise DBNeedsRebuild

--- a/tests/test_dcrpm.py
+++ b/tests/test_dcrpm.py
@@ -32,11 +32,11 @@ class TestDcRPM(testslide.TestCase):
     def setUp(self):
         # type: () -> None
         super(TestDcRPM, self).setUp()
-        self.rpm_path = "/usr/bin/rpm"  # type: str
+        self.rpm_path = util.which("rpm")  # type: str
         self.dbpath = "/var/lib/rpm"  # type: str
-        self.recover_path = "/usr/bin/db_recover"  # type: str
-        self.verify_path = "/usr/bin/db_verify"  # type: str
-        self.stat_path = "/usr/bin/db_stat"  # type: str
+        self.recover_path = util.which("db_recover")  # type: str
+        self.verify_path = util.which("db_verify")  # type: str
+        self.stat_path = util.which("db_stat")  # type: str
         self.yum_complete_transaction_path = (
             "/usr/bin/yum-complete-transaction"
         )  # type: str

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -7,7 +7,6 @@
 # file in the root directory of this source tree.
 #
 # pyre-strict
-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from tests.dcrpm_integration_test_base import DcrpmIntegrationTestBase

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -88,8 +88,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -97,7 +96,7 @@ class TestUtil(testslide.TestCase):
             .to_return_value(make_mock_popen())
             .and_assert_called_once()
         )
-        result = run_with_timeout("/bin/true", 5)
+        result = run_with_timeout(["/bin/true"], 5)
         self.assertEqual(result.returncode, 0)
 
     def test_run_with_timeout_timeout(self):
@@ -106,8 +105,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -116,7 +114,7 @@ class TestUtil(testslide.TestCase):
             .and_assert_called_once()
         )
         with self.assertRaises(DcRPMException):
-            run_with_timeout("/bin/true", 5)
+            run_with_timeout(["/bin/true"], 5)
         mock_popen.kill.assert_not_called()
 
     def test_run_with_timeout_terminates_on_timeout(self):
@@ -125,8 +123,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -135,7 +132,7 @@ class TestUtil(testslide.TestCase):
             .and_assert_called_once()
         )
         with self.assertRaises(DcRPMException):
-            run_with_timeout("/bin/true", 5)
+            run_with_timeout(["/bin/true"], 5)
         mock_popen.terminate.assert_called()
         mock_popen.kill.assert_not_called()
 
@@ -145,8 +142,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -155,7 +151,7 @@ class TestUtil(testslide.TestCase):
             .and_assert_called_once()
         )
         with self.assertRaises(DcRPMException):
-            run_with_timeout("/bin/true", 5)
+            run_with_timeout(["/bin/true"], 5)
         mock_popen.terminate.assert_called()
         mock_popen.kill.assert_called()
 
@@ -164,8 +160,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -174,15 +169,14 @@ class TestUtil(testslide.TestCase):
             .and_assert_called_once()
         )
         with self.assertRaises(DcRPMException):
-            run_with_timeout("/bin/true", 5)
+            run_with_timeout(["/bin/true"], 5)
 
     def test_run_with_timeout_no_raise_on_nonzero(self):
         # type: () -> None
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -190,7 +184,7 @@ class TestUtil(testslide.TestCase):
             .to_return_value(make_mock_popen(returncode=1))
             .and_assert_called_once()
         )
-        result = run_with_timeout("/bin/true", 5, raise_on_nonzero=False)
+        result = run_with_timeout(["/bin/true"], 5, raise_on_nonzero=False)
         self.assertEqual(result.returncode, 1)
 
     def test_run_with_timeout_no_raise_on_timeout(self):
@@ -199,8 +193,7 @@ class TestUtil(testslide.TestCase):
         (
             self.mock_callable(subprocess, "Popen")
             .for_call(
-                "/bin/true",
-                shell=True,
+                ["/bin/true"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 universal_newlines=True,
@@ -208,7 +201,7 @@ class TestUtil(testslide.TestCase):
             .to_return_value(mock_popen)
             .and_assert_called_once()
         )
-        result = run_with_timeout("/bin/true", 5, raise_on_timeout=False)
+        result = run_with_timeout(["/bin/true"], 5, raise_on_timeout=False)
         self.assertNotEqual(result.returncode, 1)
         self.assertEqual(result.stdout, "")
         self.assertEqual(result.stderr, "")


### PR DESCRIPTION
Much like #16, this reworks the `run_with_timeout` function to accept a
command argv rather than a string. This is more secure and doesn't
require running commands in a separate subshell.

Also makes a few misc improvements for testing:
* Uses the `which` utility function so tests pass properly on macOS
* Adds a `exception_to_raise` kwarg to run_with_timeout so we can choose
which exception to raise