### PR TITLE
Add e2e test for CentOS 8

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -76,3 +76,18 @@ class DcrpmIntegrationTest(DcrpmIntegrationTestBase):
         run_result = self.dcrpm.run()
         self.assertEqual(self.action_trace(), [])
         self.assertTrue(run_result)
+
+    # CentOS Linux release 8.1.1911 (Core)
+    # dnf-4.2.7-7.el8_1.noarch
+    # rpm-4.14.2-25.el8.x86_64
+    # rpm-libs-4.14.2-25.el8.x86_64
+    @RPMDB.from_file("rpmdb_centos8")
+    def test_rpmdb_centos8(self, dbpath):
+        # type: (str) -> None
+        self.rpmutil.dbpath = dbpath
+        self.rpmutil.populate_tables()
+        self.rpmutil._read_os_release = lambda: {"ID": "centos"}
+        self.dcrpm.args.dbpath = dbpath
+        run_result = self.dcrpm.run()
+        self.assertEqual(self.action_trace(), [])
+        self.assertTrue(run_result)


### PR DESCRIPTION
This uses the rpmdb from CentOS-8-GenericCloud-8.1.1911-20200113.3.x86_64.qcow2