### PR TITLE
Allow missing yum on Darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 2.7
   - 3.4
   - 3.6
+  - 3.7
 
 addons:
   apt:
@@ -20,10 +21,6 @@ addons:
 
 matrix:
   include:
-    # workaround for https://github.com/travis-ci/travis-ci/issues/9815
-    - python: 3.7
-      dist: xenial
-      sudo: true
     # workaround for https://github.com/travis-ci/travis-ci/issues/2312
     - os: osx
       language: generic

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ addons:
       - db-util
       - rpm
       - yum
+  homebrew:
+    packages:
+      - pyenv
+      - rpm
+    update: true
 
 matrix:
   include:
@@ -48,17 +53,13 @@ matrix:
 
 before_install: |
   if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-    brew update
-
     # setup python
-    brew outdated pyenv || brew upgrade pyenv
     pyenv install "$PYTHON_VERSION"
     eval "$(pyenv init -)"
     pyenv global "$PYTHON_VERSION"
     pip install -r requirements.txt
 
     # setup rpm
-    brew install rpm
     sudo mkdir -p /var/lib/rpm
   fi
 

--- a/dcrpm/yum.py
+++ b/dcrpm/yum.py
@@ -15,7 +15,14 @@ import signal
 import time
 
 from . import pidutil
-from .util import DBNeedsRebuild, DcRPMException, RepairAction, run_with_timeout, which
+from .util import (
+    DBNeedsRebuild,
+    DcRPMException,
+    RepairAction,
+    read_os_name,
+    run_with_timeout,
+    which,
+)
 
 
 YUM_PID_PATH = "/var/run/yum.pid"  # type: str
@@ -40,7 +47,12 @@ class Yum:
                 self.yum = DNF_CMD_NAME
                 which(self.yum)
             except DcRPMException:
-                raise DcRPMException("Neither yum nor dnf was found!")
+                self.yum = YUM_CMD_NAME
+                m = "Neither yum nor dnf was found!"
+                if read_os_name() == "Darwin":
+                    self.logger.warning(m)
+                else:
+                    raise DcRPMException(m)
 
         self.logger.info("Using %s for yum" % self.yum)
 


### PR DESCRIPTION
This should unbreak Travis on OSX. Ideally we'd just get Yum running there as well, but it's not in brew and compiling it from scratch in there seems overkill.