### PR TITLE
Typing imports should be optional

### DIFF
--- a/dcrpm/dcrpm.py
+++ b/dcrpm/dcrpm.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import logging
 import os
 import signal
-import typing as t
+
 from fnmatch import fnmatch
 from os.path import join
 
@@ -21,11 +21,15 @@ from . import pidutil
 from .util import DBNeedsRebuild, DBNeedsRecovery, DcRPMException, RepairAction
 from .yum import Yum
 
+try:
+    import typing as t
 
-if t.TYPE_CHECKING:
-    import argparse
+    if t.TYPE_CHECKING:
+        import argparse
 
-    from .rpmutil import RPMUtil
+        from .rpmutil import RPMUtil
+except ImportError:
+    pass
 
 
 class DcRPM:

--- a/dcrpm/main.py
+++ b/dcrpm/main.py
@@ -15,13 +15,16 @@ import json
 import logging
 import logging.config
 import sys
-import typing as t  # noqa
 
 from . import __version__
 from .dcrpm import DcRPM
 from .rpmutil import RPMUtil
 from .util import which
 
+try:
+    import typing as t  # noqa
+except ImportError:
+    pass
 
 # Some sensible defaults.
 DEFAULT_MAX_PASSES = 5  # type: int

--- a/dcrpm/pidutil.py
+++ b/dcrpm/pidutil.py
@@ -12,15 +12,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 import os
-import typing as t
 
 import psutil
 
 from .util import DcRPMException, StatusCode, TimeoutExpired, run_with_timeout, which
 
+try:
+    import typing as t
 
-if t.TYPE_CHECKING:
-    import enum
+    if t.TYPE_CHECKING:
+        import enum
+except ImportError:
+    pass
 
 
 DEFAULT_TIMEOUT = 5  # type: int

--- a/dcrpm/util.py
+++ b/dcrpm/util.py
@@ -14,19 +14,19 @@ import logging
 import os
 import signal
 import subprocess
-import typing as t
 
+try:
+    import typing as t
 
-if t.TYPE_CHECKING:
-    from types import FrameType
+    if t.TYPE_CHECKING:
+        from types import FrameType
+except ImportError:
+    pass
 
 
 END_TIMEOUT = 5  # type: int
 
 _logger = logging.getLogger()  # type: logging.Logger
-
-# Generic ReturnType
-RT = t.TypeVar("RT")
 
 
 class StatusCode:
@@ -120,13 +120,15 @@ ACTION_NAMES = {
 }  # type: t.Dict[int, str]
 
 
+# pyre-ignore[2,3]: workaround pyre bug
 def memoize(f):
-    # type: (t.Callable[..., RT]) -> t.Callable[..., RT]
-    cache = {}  # type: t.Dict[str, RT]
+    # type: (t.Callable[..., t.TypeVar("RT")]) -> t.Callable[..., t.TypeVar("RT")]
+
+    cache = {}  # type: t.Dict[str, t.TypeVar("RT")]
 
     # pyre-ignore[2]: *args and **kwargs
     def wrapper(*args, **kwargs):
-        # type: (t.Any, t.Any) -> RT
+        # type: (t.Any, t.Any) -> t.TypeVar("RT")
         key = str(args) + str(kwargs)
         if key not in cache:
             cache[key] = f(*args, **kwargs)
@@ -144,13 +146,13 @@ def alarm_handler(signum, frame):
 
 
 def call_with_timeout(
-    func,  # type: t.Callable[..., RT]
+    func,  # type: t.Callable[..., t.TypeVar("RT")]
     timeout,  # type: int
     args=None,  # type: t.Optional[t.Iterable[str]]
     # pyre-ignore[2]: kwargs has type dict[str, Any]
     kwargs=None,  # type: t.Optional[t.Dict[str, t.Any]]
 ):
-    # type: (...) -> RT
+    # type: (...) -> t.TypeVar("RT")
     """
     A generic method that calls some callable and uses SIGALRM to time out the
     call should it take longer than `timeout`.

--- a/scripts/run_pyre_venv.sh
+++ b/scripts/run_pyre_venv.sh
@@ -30,4 +30,5 @@ root=$(git rev-parse --show-toplevel)
     --output text \
     --search-path "$(get_site_packages)" \
     --search-path "$root" \
+    --show-parse-errors \
     check


### PR DESCRIPTION
Lack of typing shouldn't break runtime, so make it optional (this is especially a problem on OSX).