### PR TITLE
Relax Requirename index check

### DIFF
--- a/dcrpm/rpmutil.py
+++ b/dcrpm/rpmutil.py
@@ -202,7 +202,8 @@ class RPMUtil:
                     lambda proc: proc.returncode != StatusCode.SEGFAULT,
                     lambda proc: len(proc.stdout.splitlines()) >= 1,
                     lambda proc: any(
-                        line.startswith("rpm-") for line in proc.stdout.splitlines()
+                        line.startswith("rpm-") or line.startswith("yum-")
+                        for line in proc.stdout.splitlines()
                     ),
                 ],
             },


### PR DESCRIPTION
We found one valid case where `rpm` doesn't show up here, so relax the check to also look for yum. Longer term, these things should probably be be moved to a config file.