### PR TITLE
Switch the recommended test runner to pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,7 @@ If you want to develop, the easiest way to get dcrpm is by using pip:
 
 When developing it's important to make sure the tests continue to pass, and to ensure new features have the appropriate test coverage. You can run the test suite with:
 
-    python setup.py test
-
-which will fetch mock from pypi if needed and then run the tests.
+    pytest
 
 ## Contribute
 See the CONTRIBUTING file for how to help out.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mock; python_version < '3.6'
 psutil
+pytest
 typing; python_version < '3.6'
 TestSlide==1.4.10; python_version < '3.5'
 TestSlide; python_version >= '3.5'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -45,7 +45,9 @@ def make_mock_popen(
     Creates a simple mocked Popen object that responds to Popen.poll and
     Popen.communicate.
     """
-    mock_popen_obj = Mock()
+
+    # set PID because this is used by pytest's logging.py
+    mock_popen_obj = Mock(pid=42)
     config = {"poll.return_value": returncode}  # type: t.Dict[str, t.Any]
     if communicate_raise:
         config["communicate.side_effect"] = TimeoutExpired()


### PR DESCRIPTION
`python setup.py test` triggers a weird behavior with setuptools >= 60,
which is not encountered when using `pytest`.

Using the latter also allows downstream distributions to easily exclude
certain tests as necessary, and makes debugging easier.

This requires a fix as pytest's logging code would fail to print the PID
of the mocked process, as that property was unset.

Resolves #47.

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>