### PR TITLE
Fix YUM_PATH not exist error

### DIFF
--- a/dcrpm/dcrpm.py
+++ b/dcrpm/dcrpm.py
@@ -34,6 +34,9 @@ except ImportError:
 
 class DcRPM:
     YUM_PATH = "/var/lib/yum"  # type: str
+    if not os.path.exists(YUM_PATH):
+        YUM_PATH = "/var/lib/dnf"
+
     YUM_TRANSACTION_BASE = "*transaction-all.*"  # type: str
 
     def __init__(self, rpmutil, args):


### PR DESCRIPTION
On some OS, e.g. CentOS 8 or Fedora 36, "/var/lib/yum" doesn't exist; seems it's replaced by "/var/lib/dnf". Thus causing this error.

Before:

```
$ sudo dcrpm --clean-yum-transactions
2023-01-13 21:18:14,717 ERROR [main.main]: exception
2023-01-13 21:18:14,717 ERROR [main.main]: exception
2023-01-13 21:18:14,717 ERROR [main.main]: exception: [Errno 2] No such file or directory: '/var/lib/yum'
```

After:

```
$ sudo python setup.py install

# the error is gone
$ sudo dcrpm --clean-yum-transactions
2023-01-13 21:32:44,664 WARNING [dcrpm.run]: Table verification is not implemented for sqlite

$ pytest 
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
rootdir: /home/gengwg/dcrpm
plugins: typeguard-2.13.3
collected 67 items                                                                                                                                                                            

tests/test_dcrpm.py .........                                                                                                                                                           [ 13%]
tests/test_end_to_end.py .....                                                                                                                                                          [ 20%]
tests/test_pidutil.py ...............                                                                                                                                                   [ 43%]
tests/test_rpmutil.py ...................                                                                                                                                               [ 71%]
tests/test_util.py ...........                                                                                                                                                          [ 88%]
tests/test_yum.py ........                                                                                                                                                              [100%]

===================================================================================== 67 passed in 30.31s =====================================================================================
```

